### PR TITLE
Managed when participants/parties are None

### DIFF
--- a/bookied_sync/participant.py
+++ b/bookied_sync/participant.py
@@ -26,6 +26,8 @@ class LookupParticipants(Lookup, dict):
             participants (self)
         """
         parties = self.get("participants")
+        if type(parties) == type(None):
+            return True  #Warning: Check if it's okay to return True
         for team in parties:
             if name.lower() in [
                 x.lower() for x in team.get("name", {}).values()


### PR DESCRIPTION
The for loop iteration fails when parties is None. Hence checking if parties is None and return True when parties is None.
Warning: Make sure that returning True when parties is None is in line with expected functionality.